### PR TITLE
Update date formats strings in benchmarks

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -16,15 +16,27 @@ const speedDateFormatter = speedDate(DATE_FORMAT)
 
 const suite = new Benchmark.Suite()
 
+const now = new Date()
+
+console.table({
+  moment: moment(now).format(DATE_FORMAT),
+  'date-format': format('yyyy.MM.ddThh:mm:ss,SSS O', now),
+  'dateformat': dateFormat(now, 'yyyy.mm.dd\'T\'HH:MM:ss,l o'),
+  'fast-date-format': dateFormatter.format(now),
+  'fecha': fecha.format(now, DATE_FORMAT),
+  'speed-date': speedDateFormatter(now),
+  'date-fns': dateFnsFormat(now, 'yyyy.MM.dd\'T\'HH:mm:ss,SSS XXX')
+})
+
 suite
   .add('moment', () => {
     moment().format(DATE_FORMAT)
   })
   .add('date-format', () => {
-    format(DATE_FORMAT, new Date())
+    format('yyyy.MM.ddThh:mm:ss,SSS O', new Date())
   })
   .add('dateformat', () => {
-    dateFormat(new Date(), DATE_FORMAT)
+    dateFormat(new Date(), 'yyyy.mm.dd\'T\'HH:MM:ss,l o')
   })
   .add('fast-date-format', () => {
     dateFormatter.format(new Date())


### PR DESCRIPTION
## Problem

Some of the date formats for other libraries are invalid.


<details>
<summary>If you log the output of the benchmarks</summary>

```js
console.table({
  moment: moment(now).format(DATE_FORMAT),
  'date-format': format(DATE_FORMAT, now),
  'dateformat': dateFormat(now, DATE_FORMAT),
  'fast-date-format': dateFormatter.format(now),
  'fecha': fecha.format(now, DATE_FORMAT),
  'speed-date': speedDateFormatter(now),
  'date-fns': dateFnsFormat(now, 'yyyy.MM.dd\'T\'HH:mm:ss,SSS XXX')
})
```

</details>


You get this:


**before**

```
┌──────────────────┬─────────────────────────────────────┐
│     (index)      │               Values                │
├──────────────────┼─────────────────────────────────────┤
│      moment      │   '2023.03.09T10:50:42,404 -0600'   │
│   date-format    │    'YYYY.03.DDTHH:50:42,404 ZZ'     │
│    dateformat    │ 'YYYY.50.DDA10:03:42,ththth CSTCST' │
│ fast-date-format │  '2023.03.09T10:50:42,404 -06:00'   │
│      fecha       │   '2023.03.09T10:50:42,404 -0600'   │
│    speed-date    │   '2023.03.09T10:50:42,404 -0600'   │
│     date-fns     │  '2023.03.09T10:50:42,404 -06:00'   │
└──────────────────┴─────────────────────────────────────┘
```


## Solution



<details>
<summary>By updating the format strings:</summary>


```js
console.table({
  moment: moment(now).format(DATE_FORMAT),
  'date-format': format('yyyy.MM.ddThh:mm:ss,SSS O', now),
  'dateformat': dateFormat(now, 'yyyy.mm.dd\'T\'HH:MM:ss,l o'),
  'fast-date-format': dateFormatter.format(now),
  'fecha': fecha.format(now, DATE_FORMAT),
  'speed-date': speedDateFormatter(now),
  'date-fns': dateFnsFormat(now, 'yyyy.MM.dd\'T\'HH:mm:ss,SSS XXX')
})
```

</details>


**after**


```
┌──────────────────┬──────────────────────────────────┐
│     (index)      │              Values              │
├──────────────────┼──────────────────────────────────┤
│      moment      │ '2023.03.09T10:50:42,404 -0600'  │
│   date-format    │ '2023.03.09T16:50:42,404 -0600'  │
│    dateformat    │ '2023.03.09T10:50:42,404 -0600'  │
│ fast-date-format │ '2023.03.09T10:50:42,404 -06:00' │
│      fecha       │ '2023.03.09T10:50:42,404 -0600'  │
│    speed-date    │ '2023.03.09T10:50:42,404 -0600'  │
│     date-fns     │ '2023.03.09T10:50:42,404 -06:00' │
└──────────────────┴──────────────────────────────────┘
```

Noting `date-format` shows hour `16` instead of `10`.  This is either a bug or the behavior of that package.

